### PR TITLE
feat: Refactor introspection logic and fix package loading issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This tool introspects TypeScript packages and source code to extract exported sy
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/ts-morph-mcp-server.git
-cd ts-morph-mcp-server
+git clone https://github.com/t3ta/ts-introspect-mcp-server.git
+cd ts-introspect-mcp-server
 
 # Install dependencies
 npm install
@@ -36,10 +36,13 @@ node dist/index.js zod
 ## Usage as Library
 
 ```typescript
-import { introspectFromPackage, introspectFromSource } from 'ts-morph-mcp-server';
+import {
+  introspectFromPackage,
+  introspectFromSource,
+} from "ts-introspect-mcp-server";
 
 // Introspect a package
-const exports = await introspectFromPackage('zod');
+const exports = await introspectFromPackage("zod");
 console.log(exports);
 
 // Introspect source code
@@ -73,6 +76,7 @@ The MCP server provides the following tools:
 Introspects an npm package and returns its exported symbols.
 
 Parameters:
+
 - `packageName`: Name of the npm package to introspect (e.g., 'zod')
 
 #### introspect-source
@@ -80,6 +84,7 @@ Parameters:
 Introspects TypeScript source code and returns the exported symbols.
 
 Parameters:
+
 - `source`: TypeScript source code to analyze
 
 ## Development

--- a/docs/branch-memory-bank/feat-mcp-tool-list/activeContext.json
+++ b/docs/branch-memory-bank/feat-mcp-tool-list/activeContext.json
@@ -1,0 +1,80 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "06840479-414b-4c56-97d5-b9d01dd9e195",
+    "title": "アクティブコンテキスト",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [
+      "active-context"
+    ],
+    "lastModified": "2025-04-07T01:42:48.594Z",
+    "createdAt": "2025-04-07T01:42:48.594Z",
+    "version": 1
+  },
+  "content": {
+    "currentWork": "現在取り組んでいる作業の説明",
+    "recentChanges": [
+      {
+        "date": "2025-04-07T01:42:48.594Z",
+        "description": "変更点1"
+      },
+      {
+        "date": "2025-04-07T01:42:48.594Z",
+        "description": "変更点2"
+      },
+      {
+        "date": "2025-04-07T01:42:48.594Z",
+        "description": "変更点3"
+      }
+    ],
+    "activeDecisions": [
+      {
+        "id": "e02dc44c-9d73-4c00-836c-1f401a031161",
+        "description": "決定事項1"
+      },
+      {
+        "id": "b0276247-e4ec-4aaf-b2af-20d2a04969b5",
+        "description": "決定事項2"
+      },
+      {
+        "id": "f2657e00-476b-4760-9d6d-08d7980af594",
+        "description": "決定事項3"
+      }
+    ],
+    "considerations": [
+      {
+        "id": "10b4cd62-6941-4e81-b97e-03094435f970",
+        "description": "検討事項1",
+        "status": "open"
+      },
+      {
+        "id": "2d044352-31b3-4abe-8eef-c2f27b01f5a2",
+        "description": "検討事項2",
+        "status": "open"
+      },
+      {
+        "id": "ec0c31cf-99ca-4573-a7df-93a548acd79c",
+        "description": "検討事項3",
+        "status": "open"
+      }
+    ],
+    "nextSteps": [
+      {
+        "id": "fe748988-337a-44ca-bb58-0037648ffd4a",
+        "description": "次のステップ1",
+        "priority": "high"
+      },
+      {
+        "id": "8219d128-0436-4bf4-90ac-e478989a9af6",
+        "description": "次のステップ2",
+        "priority": "medium"
+      },
+      {
+        "id": "1f721ae0-d348-45fc-9e5c-f16b6808d715",
+        "description": "次のステップ3",
+        "priority": "low"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/feat-mcp-tool-list/branchContext.json
+++ b/docs/branch-memory-bank/feat-mcp-tool-list/branchContext.json
@@ -1,0 +1,41 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "b06fd798-a565-4736-8773-26fc971f2e21",
+    "title": "ブランチコンテキスト",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [
+      "branch-context"
+    ],
+    "lastModified": "2025-04-07T01:42:48.593Z",
+    "createdAt": "2025-04-07T01:42:48.593Z",
+    "version": 1
+  },
+  "content": {
+    "branchName": "feat/mcp-tool-list",
+    "purpose": "このブランチの目的を記述してください",
+    "createdAt": "2025-04-07T01:42:48.593Z",
+    "userStories": [
+      {
+        "id": "56c52c46-bb3c-491a-9cf4-78eb74a08574",
+        "description": "解決する課題1",
+        "completed": false,
+        "priority": 1
+      },
+      {
+        "id": "1866d1bf-3a5a-43fa-bf26-bc3d8c77dec0",
+        "description": "解決する課題2",
+        "completed": false,
+        "priority": 2
+      },
+      {
+        "id": "f94e0f65-b6d5-468d-a668-0d0231a63471",
+        "description": "解決する課題3",
+        "completed": false,
+        "priority": 3
+      }
+    ],
+    "additionalNotes": ""
+  }
+}

--- a/docs/branch-memory-bank/feat-mcp-tool-list/progress.json
+++ b/docs/branch-memory-bank/feat-mcp-tool-list/progress.json
@@ -1,0 +1,70 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "812e3c0f-d84b-4bb4-adb9-90d7da4a6a7e",
+    "title": "進捗状況",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [
+      "progress"
+    ],
+    "lastModified": "2025-04-07T01:42:48.595Z",
+    "createdAt": "2025-04-07T01:42:48.595Z",
+    "version": 1
+  },
+  "content": {
+    "workingFeatures": [
+      {
+        "id": "83c4d9d2-c07a-46ea-b36e-2d1613d00fcb",
+        "description": "機能1",
+        "implementedAt": "2025-04-07T01:42:48.595Z"
+      },
+      {
+        "id": "5cffd0c3-372c-463c-aa48-ad0d34a23ebd",
+        "description": "機能2",
+        "implementedAt": "2025-04-07T01:42:48.595Z"
+      },
+      {
+        "id": "ebfea01e-0b43-4443-b851-55d7eaea8565",
+        "description": "機能3",
+        "implementedAt": "2025-04-07T01:42:48.595Z"
+      }
+    ],
+    "pendingImplementation": [
+      {
+        "id": "92f6af5f-7fe0-49d8-8710-188961ec3ca9",
+        "description": "未実装の機能1",
+        "priority": "high"
+      },
+      {
+        "id": "97cc6a36-8ab9-42c0-9ee7-5f483d26795b",
+        "description": "未実装の機能2",
+        "priority": "medium"
+      },
+      {
+        "id": "20b6493e-d2e6-418e-9996-9789e19a528d",
+        "description": "未実装の機能3",
+        "priority": "low"
+      }
+    ],
+    "status": "現在の実装状態の説明",
+    "completionPercentage": 0,
+    "knownIssues": [
+      {
+        "id": "9af30fb5-14a6-4596-a505-04ddb2e93168",
+        "description": "問題1",
+        "severity": "high"
+      },
+      {
+        "id": "0f1626db-1236-4ca2-9d3a-c1f887358c10",
+        "description": "問題2",
+        "severity": "medium"
+      },
+      {
+        "id": "9a553d40-61ed-4a63-9239-861bb3864caa",
+        "description": "問題3",
+        "severity": "low"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/feat-mcp-tool-list/systemPatterns.json
+++ b/docs/branch-memory-bank/feat-mcp-tool-list/systemPatterns.json
@@ -1,0 +1,37 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "3325adb0-f90f-4244-ad7a-ceae4cd63cba",
+    "title": "システムパターン",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [
+      "system-patterns"
+    ],
+    "lastModified": "2025-04-07T01:42:48.595Z",
+    "createdAt": "2025-04-07T01:42:48.595Z",
+    "version": 1
+  },
+  "content": {
+    "technicalDecisions": [
+      {
+        "id": "eb8eba1d-dc6f-43ac-8903-6573267440f3",
+        "title": "決定事項のタイトル",
+        "context": "決定の背景や理由",
+        "decision": "具体的な決定内容",
+        "consequences": {
+          "positive": [
+            "影響1",
+            "影響2",
+            "影響3"
+          ],
+          "negative": []
+        },
+        "status": "proposed",
+        "date": "2025-04-07T01:42:48.595Z",
+        "alternatives": []
+      }
+    ],
+    "implementationPatterns": []
+  }
+}

--- a/docs/branch-memory-bank/feature-add-test/activeContext.json
+++ b/docs/branch-memory-bank/feature-add-test/activeContext.json
@@ -1,0 +1,80 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "6d6232e5-d8df-40cc-a3cc-338f76473812",
+    "title": "アクティブコンテキスト",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [
+      "active-context"
+    ],
+    "lastModified": "2025-04-07T01:48:07.680Z",
+    "createdAt": "2025-04-07T01:48:07.680Z",
+    "version": 1
+  },
+  "content": {
+    "currentWork": "現在取り組んでいる作業の説明",
+    "recentChanges": [
+      {
+        "date": "2025-04-07T01:48:07.680Z",
+        "description": "変更点1"
+      },
+      {
+        "date": "2025-04-07T01:48:07.680Z",
+        "description": "変更点2"
+      },
+      {
+        "date": "2025-04-07T01:48:07.680Z",
+        "description": "変更点3"
+      }
+    ],
+    "activeDecisions": [
+      {
+        "id": "11d2d283-1c08-49b8-a58b-f2d3290c1de0",
+        "description": "決定事項1"
+      },
+      {
+        "id": "853dd186-4cc5-42d3-a770-6a6ac95bfe50",
+        "description": "決定事項2"
+      },
+      {
+        "id": "2e943448-9a2a-4854-b8d8-498524329382",
+        "description": "決定事項3"
+      }
+    ],
+    "considerations": [
+      {
+        "id": "ace34867-e989-48a1-9912-8ddcadea9a76",
+        "description": "検討事項1",
+        "status": "open"
+      },
+      {
+        "id": "b5dad2b8-a98d-4ddf-ac83-1bd874f6ad18",
+        "description": "検討事項2",
+        "status": "open"
+      },
+      {
+        "id": "82ec496a-b87e-4b05-8740-e6af44eca1dc",
+        "description": "検討事項3",
+        "status": "open"
+      }
+    ],
+    "nextSteps": [
+      {
+        "id": "0a280f23-dcae-4aa2-9246-ee178b29d8f0",
+        "description": "次のステップ1",
+        "priority": "high"
+      },
+      {
+        "id": "1a54a9bb-1cdb-42c6-9bc8-5415e184ca20",
+        "description": "次のステップ2",
+        "priority": "medium"
+      },
+      {
+        "id": "ab23b2c1-d89c-47bc-8f20-8018d84a29a8",
+        "description": "次のステップ3",
+        "priority": "low"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/feature-add-test/branchContext.json
+++ b/docs/branch-memory-bank/feature-add-test/branchContext.json
@@ -1,0 +1,41 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "c1138038-4fd1-48db-b11c-ff72c0b01033",
+    "title": "ブランチコンテキスト",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [
+      "branch-context"
+    ],
+    "lastModified": "2025-04-07T01:48:07.680Z",
+    "createdAt": "2025-04-07T01:48:07.680Z",
+    "version": 1
+  },
+  "content": {
+    "branchName": "feature/add-test",
+    "purpose": "このブランチの目的を記述してください",
+    "createdAt": "2025-04-07T01:48:07.680Z",
+    "userStories": [
+      {
+        "id": "3619bcc0-a097-4d7d-bdbb-38fe8edb02e6",
+        "description": "解決する課題1",
+        "completed": false,
+        "priority": 1
+      },
+      {
+        "id": "df73a0a0-42a9-403e-8ba1-f2b84cccae99",
+        "description": "解決する課題2",
+        "completed": false,
+        "priority": 2
+      },
+      {
+        "id": "9f0feff7-2c02-426a-a448-35fe28e05e8b",
+        "description": "解決する課題3",
+        "completed": false,
+        "priority": 3
+      }
+    ],
+    "additionalNotes": ""
+  }
+}

--- a/docs/branch-memory-bank/feature-add-test/progress.json
+++ b/docs/branch-memory-bank/feature-add-test/progress.json
@@ -1,0 +1,51 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "title": "進捗状況 (feature/add-test)",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [
+      "progress",
+      "feature/add-test"
+    ]
+  },
+  "content": {
+    "workingFeatures": [],
+    "pendingImplementation": [
+      {
+        "id": "test-sdk-load",
+        "description": "tests/fromPackage.spec.ts に @modelcontextprotocol/sdk のロードテストを追加する計画",
+        "priority": "medium",
+        "details": {
+          "file": "tests/fromPackage.spec.ts",
+          "proposed_code": "test(\"introspects '@modelcontextprotocol/sdk'\", async () => {\n  const result = await introspectFromPackage(\"@modelcontextprotocol/sdk\");\n  expect(result.length).toBeGreaterThan(0);\n  // TEMP: @modelcontextprotocol/sdk の具体的なエクスポートを確認するアサーションを追加する\n});"
+        }
+      },
+      {
+        "id": "refactor-fromPackage",
+        "description": "src/introspect/fromPackage.ts を複数のファイルに分割するリファクタリング計画",
+        "priority": "high",
+        "details": {
+          "files_to_create": [
+            "src/introspect/packageResolver.ts",
+            "src/introspect/cacheUtils.ts",
+            "src/introspect/exportExtractor.ts",
+            "src/introspect/filterUtils.ts"
+          ],
+          "file_to_modify": "src/introspect/fromPackage.ts",
+          "plan": [
+            "findPackageJsonAndDir 関数を packageResolver.ts に移動",
+            "findDeclarationFiles 関数を packageResolver.ts に移動",
+            "tryLoadFromCache, saveToCache 関数を cacheUtils.ts に移動",
+            "extractExports, getExportInfo 関数を exportExtractor.ts に移動",
+            "filterExports 関数を filterUtils.ts に移動",
+            "fromPackage.ts をヘルパー関数呼び出しに書き換え"
+          ]
+        }
+      }
+    ],
+    "status": "ファイル分割計画を記録",
+    "completionPercentage": 0,
+    "knownIssues": []
+  }
+}

--- a/docs/branch-memory-bank/feature-add-test/systemPatterns.json
+++ b/docs/branch-memory-bank/feature-add-test/systemPatterns.json
@@ -1,0 +1,37 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "5e81ea7b-09e9-437b-95a4-293c6f90d620",
+    "title": "システムパターン",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [
+      "system-patterns"
+    ],
+    "lastModified": "2025-04-07T01:48:07.680Z",
+    "createdAt": "2025-04-07T01:48:07.680Z",
+    "version": 1
+  },
+  "content": {
+    "technicalDecisions": [
+      {
+        "id": "24ebcdb2-fc51-43e7-b868-9f2e701909c5",
+        "title": "決定事項のタイトル",
+        "context": "決定の背景や理由",
+        "decision": "具体的な決定内容",
+        "consequences": {
+          "positive": [
+            "影響1",
+            "影響2",
+            "影響3"
+          ],
+          "negative": []
+        },
+        "status": "proposed",
+        "date": "2025-04-07T01:48:07.680Z",
+        "alternatives": []
+      }
+    ],
+    "implementationPatterns": []
+  }
+}

--- a/docs/global-memory-bank/tags/index.json
+++ b/docs/global-memory-bank/tags/index.json
@@ -9,8 +9,8 @@
       "index",
       "meta"
     ],
-    "lastModified": "2025-04-06T15:30:51.003Z",
-    "createdAt": "2025-04-06T15:30:51.003Z",
+    "lastModified": "2025-04-07T01:59:36.658Z",
+    "createdAt": "2025-04-07T01:59:36.658Z",
     "version": 1
   },
   "content": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts-morph-mcp-server",
+  "name": "@t3ta/ts-introspect-mcp-server",
   "version": "0.1.0",
   "description": "A tool to introspect exported symbols from a TypeScript package using ts-morph and output a MCP-like schema.",
   "type": "module",

--- a/src/introspect/cacheUtils.ts
+++ b/src/introspect/cacheUtils.ts
@@ -1,0 +1,49 @@
+// src/introspect/cacheUtils.ts
+import * as fs from "fs";
+import * as path from "path";
+import { ExportInfo } from "./types.js"; // Assuming types.ts is in the same directory
+
+/**
+ * Default cache directory
+ */
+const DEFAULT_CACHE_DIR = ".ts-morph-cache";
+
+/**
+ * Tries to load exports from cache
+ */
+export function tryLoadFromCache(packageName: string, cacheDir: string = DEFAULT_CACHE_DIR): ExportInfo[] | null {
+  const cacheFilePath = path.join(process.cwd(), cacheDir, `${packageName}.json`);
+
+  if (!fs.existsSync(cacheFilePath)) {
+    return null;
+  }
+
+  try {
+    const cacheContent = fs.readFileSync(cacheFilePath, 'utf8');
+    return JSON.parse(cacheContent);
+  } catch (error) {
+    console.error(`❌ Failed to load cache for ${packageName}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Saves exports to cache
+ */
+export function saveToCache(packageName: string, exports: ExportInfo[], cacheDir: string = DEFAULT_CACHE_DIR): void {
+  const cacheDirPath = path.join(process.cwd(), cacheDir);
+
+  // Create cache directory if it doesn't exist
+  if (!fs.existsSync(cacheDirPath)) {
+    fs.mkdirSync(cacheDirPath, { recursive: true });
+  }
+
+  const cacheFilePath = path.join(cacheDirPath, `${packageName}.json`);
+
+  try {
+    fs.writeFileSync(cacheFilePath, JSON.stringify(exports, null, 2));
+    console.error(`✅ Saved ${exports.length} exports to cache: ${cacheFilePath}`);
+  } catch (error) {
+    console.error(`❌ Failed to save cache for ${packageName}:`, error);
+  }
+}

--- a/src/introspect/exportExtractor.ts
+++ b/src/introspect/exportExtractor.ts
@@ -1,0 +1,101 @@
+// src/introspect/exportExtractor.ts
+import { Node, SourceFile } from "ts-morph";
+import { ExportInfo } from "./types.js"; // Assuming types.ts is in the same directory
+
+/**
+ * Extract exports from a source file
+ */
+export function extractExports(sourceFile: SourceFile): ExportInfo[] {
+  console.error(`🔍 Extracting exports from source file...`);
+  const allExports: ExportInfo[] = [];
+  const exportSymbols = sourceFile.getExportSymbols();
+  console.error(`🔢 Found ${exportSymbols.length} export symbols`);
+
+  for (const symbol of exportSymbols) {
+    const name = symbol.getName();
+    // Reduced logging for better performance
+    // console.error(`  📝 Processing export symbol: ${name}`);
+
+    // Skip default and internal symbols
+    if (name === 'default' || name.startsWith('_')) {
+      // console.error(`  ⏭️ Skipping ${name} (default or internal)`);
+      continue;
+    }
+
+    const declarations = symbol.getDeclarations();
+    if (!declarations || declarations.length === 0) {
+      // console.error(`  ⏭️ Skipping ${name} (no declarations)`);
+      continue;
+    }
+
+    // Use the first declaration (getExportSymbols resolves re-exports)
+    const decl = declarations[0];
+    const info = getExportInfo(decl, name);
+    if (info) {
+      // Avoid duplicates just in case
+      if (!allExports.some(e => e.name === info.name)) {
+        // console.error(`  ✅ Adding export: ${name} (${info.kind})`);
+        allExports.push(info);
+      } else {
+        // console.error(`  ⏭️ Skipping duplicate: ${name}`);
+      }
+    } else {
+      // console.error(`  ⏭️ Could not get export info for: ${name}`);
+    }
+  }
+
+  console.error(`✅ Extracted ${allExports.length} exports`);
+  return allExports;
+}
+
+/**
+ * Extracts export information from a specific declaration
+ */
+function getExportInfo(node: Node, name: string): ExportInfo | null {
+  let kind: ExportInfo['kind'];
+  let typeSignature = "";
+  let description = "";
+
+  // Get JSDoc comment if available
+  if (Node.isJSDocable(node)) {
+    const jsDocs = node.getJsDocs();
+    if (jsDocs.length > 0) {
+      description = jsDocs[0].getDescription().trim();
+    }
+  }
+
+  if (Node.isTypeAliasDeclaration(node)) {
+    kind = "type";
+    typeSignature = `type ${name} = ${node.getTypeNode()?.getText() ?? "unknown"}`;
+  }
+  else if (Node.isFunctionDeclaration(node)) {
+    kind = "function";
+    typeSignature = node.getText().split("{")[0].trim();
+  }
+  else if (Node.isClassDeclaration(node)) {
+    kind = "class";
+    typeSignature = `class ${name} ${node.getExtends()?.getText() ?? ""}`;
+  }
+  else if (Node.isVariableDeclaration(node)) {
+    kind = "const";
+    typeSignature = `const ${name}: ${node.getType().getText()}`;
+  }
+  // ExportSpecifier should ideally be resolved by getExportSymbols,
+  // but handle it as a fallback if it appears directly.
+  else if (Node.isExportSpecifier(node)) {
+     // This case might indicate getExportSymbols didn't fully resolve.
+     kind = "type"; // Default to type as a guess
+     typeSignature = `export { ${node.getName()} }`;
+     description = "Re-exported symbol (unresolved)";
+  }
+  else {
+    return null;
+  }
+
+  return {
+    name,
+    kind,
+    typeSignature,
+    description,
+  };
+}

--- a/src/introspect/filterUtils.ts
+++ b/src/introspect/filterUtils.ts
@@ -1,0 +1,29 @@
+// src/introspect/filterUtils.ts
+import { ExportInfo } from "./types.js"; // Assuming types.ts is in the same directory
+
+/**
+ * Filters exports based on search term and limit
+ */
+export function filterExports(exports: ExportInfo[], searchTerm?: string, limit?: number): ExportInfo[] {
+  let result = exports;
+
+  // Apply search term filter if provided
+  if (searchTerm) {
+    const regex = new RegExp(searchTerm, 'i');
+    result = exports.filter(exp =>
+      regex.test(exp.name) ||
+      regex.test(exp.typeSignature) ||
+      regex.test(exp.description)
+    );
+
+    console.error(`🔍 Filtered to ${result.length} exports matching "${searchTerm}"`);
+  }
+
+  // Apply limit if provided
+  if (limit !== undefined && limit > 0) {
+    result = result.slice(0, limit);
+    console.error(`📊 Limited to ${result.length} exports`);
+  }
+
+  return result;
+}

--- a/src/introspect/fromPackage.ts
+++ b/src/introspect/fromPackage.ts
@@ -1,17 +1,12 @@
 // src/introspect/fromPackage.ts
 import { Project, Node, SourceFile, ModuleResolutionKind } from "ts-morph";
 import { ExportInfo, IntrospectOptions } from "./types.js";
-import * as fs from "fs";
-import * as path from "path";
-import { createRequire } from "module";
+import * as fs from "fs"; // Add missing fs import
+import { tryLoadFromCache, saveToCache } from "./cacheUtils.js";
+import { filterExports } from "./filterUtils.js";
+import { extractExports } from "./exportExtractor.js";
+import { findPackageJsonAndDir, findDeclarationFiles } from "./packageResolver.js"; // Import package resolver utils
 
-// Create a require function that works in ESM
-const require = createRequire(import.meta.url);
-
-/**
- * Default cache directory
- */
-const DEFAULT_CACHE_DIR = ".ts-morph-cache";
 
 /**
  * Extracts export information from a package's TypeScript declaration files
@@ -27,12 +22,12 @@ export async function introspectFromPackage(
     searchPaths = [],
     searchTerm,
     cache = false,
-    cacheDir = DEFAULT_CACHE_DIR,
+    cacheDir, // Default value is handled in cacheUtils
     limit
   } = options;
 
   console.error(`🔎 Introspecting package: ${packageName}...`);
-  
+
   // Try to load from cache first if enabled
   if (cache) {
     const cachedExports = tryLoadFromCache(packageName, cacheDir);
@@ -43,7 +38,7 @@ export async function introspectFromPackage(
   }
 
   console.error(`🔍 Search paths: ${[process.cwd(), ...searchPaths].join(', ')}`);
-  
+
   const project = new Project({
     compilerOptions: {
       allowJs: true,
@@ -52,164 +47,54 @@ export async function introspectFromPackage(
       skipLibCheck: true,
       moduleResolution: ModuleResolutionKind.NodeJs,
       // Performance optimizations
-      noResolve: true,
+      // TEMP: Re-disable performance options as they caused issues
+      // noResolve: true,
     },
     skipAddingFilesFromTsConfig: true,
-    skipFileDependencyResolution: true, // Disable dependency resolution to improve performance
-    useInMemoryFileSystem: true, // Use in-memory file system for better performance
+    // TEMP: Re-disable performance options as they caused issues
+    // skipFileDependencyResolution: true, // Disable dependency resolution to improve performance
+    // TEMP: Re-disable in-memory file system as it caused issues
+    // useInMemoryFileSystem: true, // Use in-memory file system for better performance
     tsConfigFilePath: undefined,
   });
 
   try {
-    console.error(`📄 Finding package.json for ${packageName}...`);
-    
-    // Initialize packageJsonPath as empty to satisfy TypeScript
-    let packageJsonPath = "";
-    let packageDir = "";
-    let packageJson: any = {};
-    let found = false;
-    
-    // Try to find package.json using require.resolve first - fastest method
-    try {
-      packageJsonPath = require.resolve(`${packageName}/package.json`);
-      console.error(`✅ Found package.json at: ${packageJsonPath} (via require.resolve)`);
-      
-      packageDir = path.dirname(packageJsonPath);
-      
-      // Read and parse package.json
-      const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
-      packageJson = JSON.parse(packageJsonContent);
-      found = true;
-    } catch (error) {
-      // Just silently continue to the next method
-      // console.error(`❌ Could not resolve ${packageName}/package.json via require:`, error);
-    }
-    
-    // If not found, try the additional search paths
-    if (!found) {
-      // All possible package.json locations to check
-      const possiblePaths: string[] = [
-        // Standard node_modules locations
-        path.join(process.cwd(), 'node_modules', packageName, 'package.json'),
-        ...searchPaths.map(searchPath => 
-          path.join(searchPath, 'node_modules', packageName, 'package.json')
-        ),
-        
-        // pnpm specific paths - try both with version and without
-        // For direct packages (e.g. 'zod')
-        path.join(process.cwd(), 'node_modules', '.pnpm', `${packageName}@*`, 'node_modules', packageName, 'package.json'),
-        path.join(process.cwd(), 'node_modules', '.pnpm', packageName, 'node_modules', packageName, 'package.json'),
-        
-        // For subpath packages (e.g. '@modelcontextprotocol/sdk')
-        ...(packageName.includes('/') ? [
-          // Handle @scope/package format
-          path.join(process.cwd(), 'node_modules', '.pnpm', packageName.replace('/', '+')+'@*', 'node_modules', packageName, 'package.json'),
-          path.join(process.cwd(), 'node_modules', '.pnpm', packageName.replace('/', '+'), 'node_modules', packageName, 'package.json')
-        ] : []),
-        
-        // Search in provided paths
-        ...searchPaths.map(searchPath => 
-          path.join(searchPath, 'node_modules', '.pnpm', `${packageName}@*`, 'node_modules', packageName, 'package.json')
-        ),
-        ...searchPaths.map(searchPath => 
-          path.join(searchPath, 'node_modules', '.pnpm', packageName, 'node_modules', packageName, 'package.json')
-        ),
-        
-        // Search in provided paths for subpath packages
-        ...(packageName.includes('/') ? searchPaths.flatMap(searchPath => [
-          path.join(searchPath, 'node_modules', '.pnpm', packageName.replace('/', '+')+'@*', 'node_modules', packageName, 'package.json'),
-          path.join(searchPath, 'node_modules', '.pnpm', packageName.replace('/', '+'), 'node_modules', packageName, 'package.json')
-        ]) : []),
-        
-        // Direct package paths (least likely, but worth checking)
-        ...searchPaths.map(searchPath => 
-          path.join(searchPath, packageName, 'package.json')
-        ),
-      ];
-      
-      for (const possiblePath of possiblePaths) {
-        // Less verbose logging
-        // console.error(`🔍 Checking path: ${possiblePath}`);
-        if (fs.existsSync(possiblePath)) {
-          packageJsonPath = possiblePath;
-          console.error(`✅ Found package.json at: ${packageJsonPath}`);
-          
-          packageDir = path.dirname(packageJsonPath);
-          
-          // Read and parse package.json
-          const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
-          packageJson = JSON.parse(packageJsonContent);
-          
-          found = true;
-          break;
-        }
-      }
-    }
-    
-    if (!found) {
-      throw new Error(`Could not find package.json for ${packageName} in any search paths`);
-    }
-    
-    console.error(`📝 Package.json parsed:`, { 
-      name: packageJson.name, 
-      version: packageJson.version,
-      types: packageJson.types,
-      typings: packageJson.typings,
-      hasExports: !!packageJson.exports
-    });
-
-    // First check types/typings field
-    let typesPath = packageJson.types || packageJson.typings;
-    console.error(`🔤 Types path from package.json:`, typesPath);
-
-    // If no explicit types field, check exports
-    if (!typesPath && packageJson.exports) {
-      typesPath = packageJson.exports['.']?.types;
-      console.error(`🔤 Types path from exports:`, typesPath);
+    // 1. Find package.json and the real package directory
+    const packageInfo = findPackageJsonAndDir(packageName, searchPaths);
+    if (!packageInfo) {
+      // Error logged within findPackageJsonAndDir
+      return [];
     }
 
-    // If still no types path, try common locations
-    if (!typesPath) {
-      typesPath = 'index.d.ts';
-      console.error(`🔤 Using default types path:`, typesPath);
+    // 2. Find all relevant declaration (.d.ts) files
+    const declarationFiles = findDeclarationFiles(packageInfo);
+    if (declarationFiles.length === 0) {
+       // Error logged within findDeclarationFiles
+       return [];
     }
 
-    // Resolve the full path relative to package directory
-    const mainDtsPath = path.join(packageDir, typesPath.startsWith('./') ? typesPath.slice(2) : typesPath);
-    console.error(`📄 Full path to declaration file: ${mainDtsPath}`);
-
+    // 3. Add declaration files to the ts-morph project and extract exports
     let allExports: ExportInfo[] = [];
+    for (const filePath of declarationFiles) {
+       console.error(`📄 Attempting to load and extract from: ${filePath}`);
+       if (!fs.existsSync(filePath)) { // Double check existence before adding
+           console.error(`  ❌ File does not exist (skipped): ${filePath}`);
+           continue;
+       }
+       try {
+           const sourceFile = project.addSourceFileAtPath(filePath);
+           console.error(`  ✅ Source file added to project: ${filePath}`);
+           const fileExports = extractExports(sourceFile);
+           allExports = allExports.concat(fileExports); // Combine exports
+           console.error(`  📊 Found ${fileExports.length} exports in this file. Total exports now: ${allExports.length}`);
+       } catch (fileError) {
+           console.error(`  ❌ Failed to load or extract exports from ${filePath}:`, fileError);
+           // Optionally decide whether to continue or re-throw
+       }
+    }
 
-    if (!fs.existsSync(mainDtsPath)) {
-      console.error(`❌ Type definitions not found at ${mainDtsPath}`);
-      
-      // Attempt to find .d.ts files in the package
-      const files = fs.readdirSync(packageDir)
-        .filter(file => file.endsWith('.d.ts'));
-      
-      console.error(`🔍 Found ${files.length} .d.ts files in package directory:`, files);
-      
-      if (files.length === 0) {
-        throw new Error(`Type definitions not found at ${mainDtsPath}`);
-      }
-      
-      // Use the first .d.ts file found
-      const alternativePath = path.join(packageDir, files[0]);
-      console.error(`📄 Using alternative declaration file: ${alternativePath}`);
-      
-      // Add the main file to the project
-      const sourceFile = project.addSourceFileAtPath(alternativePath);
-      console.error(`📄 Source file added to project`);
-      
-      // Extract exports using getExportSymbols
-      allExports = extractExports(sourceFile);
-    } else {
-      // Add the main file to the project
-      const sourceFile = project.addSourceFileAtPath(mainDtsPath);
-      console.error(`📄 Source file added to project`);
-
-      // Extract exports using getExportSymbols
-      allExports = extractExports(sourceFile);
+    if (allExports.length === 0) {
+        console.error(`⚠️ No exports could be extracted from any found .d.ts files for package ${packageName}`);
     }
 
     // Save to cache if enabled
@@ -223,169 +108,4 @@ export async function introspectFromPackage(
     console.error(`❌ Failed to load declaration file for package ${packageName}:`, error);
     return [];
   }
-}
-
-/**
- * Extract exports from a source file
- */
-function extractExports(sourceFile: SourceFile): ExportInfo[] {
-  console.error(`🔍 Extracting exports from source file...`);
-  const allExports: ExportInfo[] = [];
-  const exportSymbols = sourceFile.getExportSymbols();
-  console.error(`🔢 Found ${exportSymbols.length} export symbols`);
-
-  for (const symbol of exportSymbols) {
-    const name = symbol.getName();
-    // Reduced logging for better performance
-    // console.error(`  📝 Processing export symbol: ${name}`);
-    
-    // Skip default and internal symbols
-    if (name === 'default' || name.startsWith('_')) {
-      // console.error(`  ⏭️ Skipping ${name} (default or internal)`);
-      continue;
-    }
-
-    const declarations = symbol.getDeclarations();
-    if (!declarations || declarations.length === 0) {
-      // console.error(`  ⏭️ Skipping ${name} (no declarations)`);
-      continue;
-    }
-
-    // Use the first declaration (getExportSymbols resolves re-exports)
-    const decl = declarations[0];
-    const info = getExportInfo(decl, name);
-    if (info) {
-      // Avoid duplicates just in case
-      if (!allExports.some(e => e.name === info.name)) {
-        // console.error(`  ✅ Adding export: ${name} (${info.kind})`);
-        allExports.push(info);
-      } else {
-        // console.error(`  ⏭️ Skipping duplicate: ${name}`);
-      }
-    } else {
-      // console.error(`  ⏭️ Could not get export info for: ${name}`);
-    }
-  }
-
-  console.error(`✅ Extracted ${allExports.length} exports`);
-  return allExports;
-}
-
-/**
- * Extracts export information from a specific declaration
- */
-function getExportInfo(node: Node, name: string): ExportInfo | null {
-  let kind: ExportInfo['kind'];
-  let typeSignature = "";
-  let description = "";
-
-  // Get JSDoc comment if available
-  if (Node.isJSDocable(node)) {
-    const jsDocs = node.getJsDocs();
-    if (jsDocs.length > 0) {
-      description = jsDocs[0].getDescription().trim();
-    }
-  }
-
-  if (Node.isTypeAliasDeclaration(node)) {
-    kind = "type";
-    typeSignature = `type ${name} = ${node.getTypeNode()?.getText() ?? "unknown"}`;
-  }
-  else if (Node.isFunctionDeclaration(node)) {
-    kind = "function";
-    typeSignature = node.getText().split("{")[0].trim();
-  }
-  else if (Node.isClassDeclaration(node)) {
-    kind = "class";
-    typeSignature = `class ${name} ${node.getExtends()?.getText() ?? ""}`;
-  }
-  else if (Node.isVariableDeclaration(node)) {
-    kind = "const";
-    typeSignature = `const ${name}: ${node.getType().getText()}`;
-  }
-  // ExportSpecifier should ideally be resolved by getExportSymbols,
-  // but handle it as a fallback if it appears directly.
-  else if (Node.isExportSpecifier(node)) {
-     // This case might indicate getExportSymbols didn't fully resolve.
-     kind = "type"; // Default to type as a guess
-     typeSignature = `export { ${node.getName()} }`;
-     description = "Re-exported symbol (unresolved)";
-  }
-  else {
-    return null;
-  }
-
-  return {
-    name,
-    kind,
-    typeSignature,
-    description,
-  };
-}
-
-/**
- * Tries to load exports from cache
- */
-function tryLoadFromCache(packageName: string, cacheDir: string): ExportInfo[] | null {
-  const cacheFilePath = path.join(process.cwd(), cacheDir, `${packageName}.json`);
-  
-  if (!fs.existsSync(cacheFilePath)) {
-    return null;
-  }
-  
-  try {
-    const cacheContent = fs.readFileSync(cacheFilePath, 'utf8');
-    return JSON.parse(cacheContent);
-  } catch (error) {
-    console.error(`❌ Failed to load cache for ${packageName}:`, error);
-    return null;
-  }
-}
-
-/**
- * Saves exports to cache
- */
-function saveToCache(packageName: string, exports: ExportInfo[], cacheDir: string): void {
-  const cacheDirPath = path.join(process.cwd(), cacheDir);
-  
-  // Create cache directory if it doesn't exist
-  if (!fs.existsSync(cacheDirPath)) {
-    fs.mkdirSync(cacheDirPath, { recursive: true });
-  }
-  
-  const cacheFilePath = path.join(cacheDirPath, `${packageName}.json`);
-  
-  try {
-    fs.writeFileSync(cacheFilePath, JSON.stringify(exports, null, 2));
-    console.error(`✅ Saved ${exports.length} exports to cache: ${cacheFilePath}`);
-  } catch (error) {
-    console.error(`❌ Failed to save cache for ${packageName}:`, error);
-  }
-}
-
-/**
- * Filters exports based on search term and limit
- */
-function filterExports(exports: ExportInfo[], searchTerm?: string, limit?: number): ExportInfo[] {
-  let result = exports;
-  
-  // Apply search term filter if provided
-  if (searchTerm) {
-    const regex = new RegExp(searchTerm, 'i');
-    result = exports.filter(exp => 
-      regex.test(exp.name) || 
-      regex.test(exp.typeSignature) || 
-      regex.test(exp.description)
-    );
-    
-    console.error(`🔍 Filtered to ${result.length} exports matching "${searchTerm}"`);
-  }
-  
-  // Apply limit if provided
-  if (limit !== undefined && limit > 0) {
-    result = result.slice(0, limit);
-    console.error(`📊 Limited to ${result.length} exports`);
-  }
-  
-  return result;
 }

--- a/src/introspect/packageResolver.ts
+++ b/src/introspect/packageResolver.ts
@@ -1,0 +1,170 @@
+// src/introspect/packageResolver.ts
+import * as fs from "fs";
+import * as path from "path";
+import { createRequire } from "module";
+
+// Create a require function that works in ESM
+const require = createRequire(import.meta.url);
+
+interface PackageInfo {
+  packageJsonPath: string;
+  packageDir: string;
+  packageJson: any;
+}
+
+/**
+ * Finds the package.json file for a given package name and returns its path,
+ * the real directory path (resolving symlinks), and the parsed JSON content.
+ * @param packageName Name of the package
+ * @param searchPaths Additional paths to search within
+ * @returns Object containing package info, or null if not found
+ */
+export function findPackageJsonAndDir(packageName: string, searchPaths: string[] = []): PackageInfo | null {
+  console.error(`📄 Finding package.json for ${packageName}...`);
+
+  let packageJsonPath = "";
+  let packageDir = "";
+  let packageJson: any = {};
+  let found = false;
+
+  // Try to find package.json using require.resolve first - fastest method
+  try {
+    packageJsonPath = require.resolve(`${packageName}/package.json`);
+    console.error(`✅ Found package.json at: ${packageJsonPath} (via require.resolve)`);
+
+    // Resolve symbolic links for pnpm compatibility
+    packageDir = fs.realpathSync(path.dirname(packageJsonPath));
+    console.error(`✅ Real package directory: ${packageDir}`);
+
+    // Read and parse package.json
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    packageJson = JSON.parse(packageJsonContent);
+    found = true;
+  } catch (error) {
+    // Just silently continue to the next method
+  }
+
+  // If not found, try the additional search paths
+  if (!found) {
+    const possiblePaths: string[] = [
+      // Standard node_modules locations
+      path.join(process.cwd(), 'node_modules', packageName, 'package.json'),
+      ...searchPaths.map(searchPath =>
+        path.join(searchPath, 'node_modules', packageName, 'package.json')
+      ),
+      // pnpm specific paths
+      path.join(process.cwd(), 'node_modules', '.pnpm', `${packageName}@*`, 'node_modules', packageName, 'package.json'),
+      path.join(process.cwd(), 'node_modules', '.pnpm', packageName, 'node_modules', packageName, 'package.json'),
+      ...(packageName.includes('/') ? [
+        path.join(process.cwd(), 'node_modules', '.pnpm', packageName.replace('/', '+')+'@*', 'node_modules', packageName, 'package.json'),
+        path.join(process.cwd(), 'node_modules', '.pnpm', packageName.replace('/', '+'), 'node_modules', packageName, 'package.json')
+      ] : []),
+      // Search in provided paths
+      ...searchPaths.map(searchPath =>
+        path.join(searchPath, 'node_modules', '.pnpm', `${packageName}@*`, 'node_modules', packageName, 'package.json')
+      ),
+      ...searchPaths.map(searchPath =>
+        path.join(searchPath, 'node_modules', '.pnpm', packageName, 'node_modules', packageName, 'package.json')
+      ),
+      ...(packageName.includes('/') ? searchPaths.flatMap(searchPath => [
+        path.join(searchPath, 'node_modules', '.pnpm', packageName.replace('/', '+')+'@*', 'node_modules', packageName, 'package.json'),
+        path.join(searchPath, 'node_modules', '.pnpm', packageName.replace('/', '+'), 'node_modules', packageName, 'package.json')
+      ]) : []),
+      // Direct package paths
+      ...searchPaths.map(searchPath =>
+        path.join(searchPath, packageName, 'package.json')
+      ),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      if (fs.existsSync(possiblePath)) {
+        packageJsonPath = possiblePath;
+        console.error(`✅ Found package.json at: ${packageJsonPath}`);
+
+        // Resolve symbolic links for pnpm compatibility
+        packageDir = fs.realpathSync(path.dirname(packageJsonPath));
+        console.error(`✅ Real package directory (fallback): ${packageDir}`);
+
+        // Read and parse package.json
+        const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+        packageJson = JSON.parse(packageJsonContent);
+
+        found = true;
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    console.error(`❌ Could not find package.json for ${packageName} in any search paths`);
+    return null;
+  }
+
+  console.error(`📝 Package.json parsed:`, {
+    name: packageJson.name,
+    version: packageJson.version,
+    types: packageJson.types,
+    typings: packageJson.typings,
+    hasExports: !!packageJson.exports
+  });
+
+  return { packageJsonPath, packageDir, packageJson };
+}
+
+/**
+ * Finds the list of declaration file paths to load for a package.
+ * @param packageInfo Information about the package (path, dir, json content)
+ * @returns Array of absolute paths to .d.ts files
+ */
+export function findDeclarationFiles(packageInfo: PackageInfo): string[] {
+  const { packageJsonPath, packageDir, packageJson } = packageInfo;
+  const packageJsonDir = path.dirname(packageJsonPath);
+
+  // 1. Check types/typings field
+  let typesPath = packageJson.types || packageJson.typings;
+  console.error(`🔤 Types path from package.json:`, typesPath);
+
+  // 2. If no explicit types field, check exports
+  if (!typesPath && packageJson.exports) {
+    typesPath = packageJson.exports['.']?.types;
+    console.error(`🔤 Types path from exports:`, typesPath);
+  }
+
+  // 3. If still no types path, try common locations (index.d.ts)
+  if (!typesPath) {
+    typesPath = 'index.d.ts';
+    console.error(`🔤 Using default types path:`, typesPath);
+  }
+
+  // Resolve the main declaration file path relative to package.json directory
+  const mainDtsPath = path.resolve(packageJsonDir, typesPath.startsWith('./') ? typesPath.slice(2) : typesPath);
+  console.error(`📄 Resolved full path to main declaration file: ${mainDtsPath} (relative to ${packageJsonDir})`);
+
+  if (fs.existsSync(mainDtsPath)) {
+    console.error(`✅ Main declaration file exists: ${mainDtsPath}`);
+    return [mainDtsPath]; // Return only the main file if it exists
+  } else {
+    console.error(`❌ Main type definition file not found at ${mainDtsPath}. Attempting to load all .d.ts files in the package directory.`);
+
+    // Attempt to find and load all .d.ts files in the actual package directory
+    try {
+      const files = fs.readdirSync(packageDir)
+        .filter(file => file.endsWith('.d.ts'));
+
+      console.error(`🔍 Found ${files.length} .d.ts files in package directory:`, files);
+
+      if (files.length === 0) {
+        throw new Error(`No type definition files (.d.ts) found in package directory: ${packageDir}`);
+      }
+
+      // Return the absolute paths of all found .d.ts files
+      const declarationFiles = files.map(file => path.resolve(packageJsonDir, file));
+      console.error(`📄 Returning all found declaration files:`, declarationFiles);
+      return declarationFiles;
+
+    } catch (readDirError) {
+       console.error(`❌ Error reading package directory ${packageDir}:`, readDirError);
+       throw new Error(`Failed to read package directory ${packageDir} to find declaration files.`);
+    }
+  }
+}

--- a/tests/fromPackage.spec.ts
+++ b/tests/fromPackage.spec.ts
@@ -8,3 +8,11 @@ describe("introspectFromPackage", () => {
     expect(result.some(e => e.name === "z")).toBe(true);
   });
 });
+
+  test("introspects '@modelcontextprotocol/sdk'", async () => {
+    const result = await introspectFromPackage("@modelcontextprotocol/sdk");
+    // Check if any exports were found (actual check)
+    expect(result.length).toBeGreaterThan(0);
+    // Optionally, add a more specific check if you know an expected export
+    // expect(result.some(e => e.name === "InitializeRequestSchema")).toBe(true);
+  });


### PR DESCRIPTION
- Refactored `introspectFromPackage` into smaller, reusable functions in separate files (`packageResolver`, `cacheUtils`, `exportExtractor`, `filterUtils`).

- Fixed issues with resolving package paths and type definition files, especially in pnpm environments.

- Improved handling of packages with multiple declaration files.

- Added tests for `@modelcontextprotocol/sdk` loading.

- Updated package name to `@t3ta/ts-introspect-mcp-server`.